### PR TITLE
ENHANCED: use pcre2 library instead of pcre1

### DIFF
--- a/cmake/FindPCRE.cmake
+++ b/cmake/FindPCRE.cmake
@@ -14,15 +14,18 @@
 #   NOTE: PCRE_FOUND refers to library(pcre) [Prolog package]
 #         PCRE_LIBRARIES, PCRE_INCLUDE_DIRS refer to the foreign code (libpcre2-8.so etc)
 #
-# PCRE_INCLUDE_DIRS	- where to find pcre.h, etc.
-# PCRE_LIBRARIES	- List of libraries when using pcre.
-# PCRE_FOUND		- True if pcre found.
+# PCRE_INCLUDE_DIRS	- where to find pcre2.h, etc.
+# PCRE_LIBRARIES	- List of libraries when using pcre2.
+# PCRE_FOUND		- True if pcre2 found.
 
 # Look for the header file.
-find_path(PCRE_INCLUDE_DIR NAMES pcre.h)
+# TODO: verify the version is at least 10.39. (oldest pcre2 version is 10.10: https://www.pcre.org/changelog.txt)
+find_path(PCRE_INCLUDE_DIR NAMES pcre2.h)
 
-# Look for the library.
-find_library(PCRE_LIBRARY NAMES pcre)
+# Look for the library
+# - sets PCRE_LIBRARY (e.g.: /usr/lib/x86_64-linux-gnu/libpcre2-8.so),
+#        PCRE_INCLUDE_DIR (e.g., /usr/include)
+find_library(PCRE_LIBRARY NAMES pcre2-8)
 
 # Handle the QUIETLY and REQUIRED arguments and set PCRE_FOUND to TRUE if all listed variables are TRUE.
 include(FindPackageHandleStandardArgs)


### PR DESCRIPTION
This is a preliminary commit, to review some design decisions:
- `bsr2`, `newline2` because the underlying number codes changed
- slightly different way of processing options, due to pcre2 changing some of its api (bsr, newline, amongst others)
- dropped some code that tried to do stack allocation instead of malloc (instead just use the `pcre2_compile_context_create()`)

There are also some TODOs that will be removed.

Please verify that I've followed the C formatting conventions (it's not a style that I normally use).

When all the reviews are done (including a detailed check of all the options), the various commits will be squashed into a single commit.