### PR TITLE
Add "symbol" to blob, to allow better error messages

### DIFF
--- a/pcre4pl.c
+++ b/pcre4pl.c
@@ -115,7 +115,8 @@ typedef struct re_options_flags
 */
 
 typedef struct re_data
-{ atom_t            pattern;		/* pattern (as atom) */
+{ atom_t            symbol;		/* regex as blob - for error terms */
+  atom_t            pattern;		/* pattern (as atom) */
   re_options_flags  compile_options_flags;
   re_options_flags  capture_type;	/* Default capture_type: cap_type */
   re_options_flags  optimise_flags;     /* Turns on JIT */
@@ -133,6 +134,7 @@ typedef struct re_data
 
 static int re_compile_impl(re_data *re, size_t len, char *pats);
 
+static void   acquire_pcre(atom_t symbol);
 static int    release_pcre(atom_t symbol);
 static int    compare_pcres(atom_t a, atom_t b);
 static int    write_pcre(IOSTREAM *s, atom_t symbol, int flags);
@@ -143,6 +145,7 @@ static PL_blob_t pcre2_blob =
 { .magic   = PL_BLOB_MAGIC,
   .flags   = 0,
   .name    = "regex",
+  .acquire = acquire_pcre,
   .release = release_pcre,
   .compare = compare_pcres,
   .write   = write_pcre,
@@ -201,6 +204,15 @@ free_pcre(re_data *re)
   return TRUE;
 }
 
+
+static void
+acquire_pcre(atom_t symbol)
+{ re_data *re = PL_blob_data(symbol, NULL, NULL);
+
+  re->symbol = symbol;
+}
+
+
 static int
 release_pcre(atom_t symbol)
 { re_data *re = PL_blob_data(symbol, NULL, NULL);
@@ -214,6 +226,7 @@ static functor_t FUNCTOR_pair2;		/* -/2 */
 		 *	  SYMBOL WRAPPER	*
 		 *******************************/
 
+#define CMP_FIELD(fld) if (rea->fld.flags < reb->fld.flags) return -1; if (rea->fld.flags > reb->fld.flags) return 1
 
 static int
 compare_pcres(atom_t a, atom_t b)
@@ -236,11 +249,26 @@ compare_pcres(atom_t a, atom_t b)
   if ( comparison )
     return comparison;
 
-  /* Same pattern, so use address (which is stable) to break tie: */
+  CMP_FIELD(compile_options_flags);
+  CMP_FIELD(capture_type);
+  CMP_FIELD(optimise_flags);
+  CMP_FIELD(jit_options_flags);
+  CMP_FIELD(compile_ctx_flags);
+  CMP_FIELD(compile_bsr_flags);
+  CMP_FIELD(compile_newline_flags);
+  CMP_FIELD(match_options_flags);
+  CMP_FIELD(start_flags);
+
+  /* No need to compare capture_names because they because they are
+     derived from the patterns */
+
+  /* Equal so far, so use address (which is stable) to break tie: */
   return ( (rea > reb) ?  1 :
 	   (rea < reb) ? -1 : 0
 	 );
 }
+
+#undef CMP_FIELD
 
 
 static int
@@ -1103,9 +1131,9 @@ init_capture_map(re_data *re)
        pcre2_pattern_info(re->re_compiled, PCRE2_INFO_NAMECOUNT,     &name_count)      !=0 ||
        pcre2_pattern_info(re->re_compiled, PCRE2_INFO_NAMEENTRYSIZE, &name_entry_size) !=0 ||
        pcre2_pattern_info(re->re_compiled, PCRE2_INFO_NAMETABLE,     &table)	      !=0 )
-    return PL_resource_error("pcre2_pattern_info");
+    return PL_resource_error("pcre2_pattern_info"); // TODO: add re->symbol
   if ( ! (re->capture_names = malloc((re->capture_size+1) * sizeof (cap_how))) )
-    return PL_resource_error("memory");
+    return PL_resource_error("memory"); // TODO: add re->symbol
   for(uint32_t i=0; i<re->capture_size+1; i++)
   { re->capture_names[i].name = 0;
     re->capture_names[i].type = CAP_DEFAULT;
@@ -1374,21 +1402,21 @@ re_compile_impl(re_data *re, size_t len, char *pats)
   if ( re->compile_bsr_flags.flags )
   { ensure_compile_context(&compile_ctx);
     if ( 0 != pcre2_set_bsr(compile_ctx, re->compile_bsr_flags.flags) )
-    { rc = PL_representation_error("option:bsr"); /* Should never happen */
+    { rc = PL_representation_error("option:bsr"); /* TODO: add re->symbol (but should never happen) */
       goto out;
     }
   }
   if ( re->compile_newline_flags.flags )
   { ensure_compile_context(&compile_ctx);
     if ( 0 != pcre2_set_newline(compile_ctx, re->compile_newline_flags.flags) )
-    { rc = PL_representation_error("option:newline"); /* Should never happen */
+    { rc = PL_representation_error("option:newline"); /* TODO: add re->symbol (but should never happen) */
       goto out;
     }
   }
   if ( re->compile_ctx_flags.flags )
   { ensure_compile_context(&compile_ctx);
     if ( 0 != pcre2_set_compile_extra_options(compile_ctx, re->compile_ctx_flags.flags) )
-    { rc = PL_representation_error("option:extra"); /* Should never happen */
+    { rc = PL_representation_error("option:extra"); /* TODO: add re->symbol (but should never happen) */
       goto out;
     }
   }
@@ -1424,7 +1452,7 @@ re_compile_impl(re_data *re, size_t len, char *pats)
 static int
 re_verify_pats(size_t len, char *pats)
 { if ( strlen(pats) != len )		/* TBD: escape as \0x */
-    return PL_representation_error("nul_byte");
+    return PL_representation_error("nul_byte"); /* TODO: add re->symbol */
   return TRUE;
 }
 
@@ -1778,4 +1806,3 @@ install_pcre4pl(void)
   PL_register_foreign("re_portray",   2, re_portray_,  0);
   PL_register_foreign("re_portray_match_options", 2, re_portray_match_options_, 0);
 }
-

--- a/test_pcre.pl
+++ b/test_pcre.pl
@@ -71,20 +71,11 @@ test_pcre :-
     run_tests([ pcre
 	      ]).
 
-% TODO: make this part of plunit?
-%       see https://swi-prolog.discourse.group/t/plunit-and-individual-test-setup-cleanup/4853
-:- dynamic seen_re_test/1.
-:- retractall(seen_re_test(_)).
-
 term_expansion((re_test(Name) :- Body),
                   (test(Name, Options2) :- Body)) :-
-    ( seen_re_test(Name) -> throw(error(dup_re_test(Name), _)) ; true ),
-    assertz(seen_re_test(Name)),
     expand_re_test_options([], Options2).
 term_expansion((re_test(Name, Options) :- Body),
                   (test(Name, Options2) :- Body)) :-
-    ( seen_re_test(Name) -> throw(error(dup_re_test(Name), _)) ; true ),
-    assertz(seen_re_test(Name)),
     expand_re_test_options(Options, Options2).
 :- det(expand_re_test_options/2).
 expand_re_test_options([], Options2) =>


### PR DESCRIPTION
Make blob comparison more deterministic
Remove unnecessary code in unit tests (duplicate test IDs are allowed)