### PR TITLE
Fix FindPCRE.cmake to handle vcpkg debug/release libraries on Windows

### DIFF
--- a/cmake/FindPCRE.cmake
+++ b/cmake/FindPCRE.cmake
@@ -25,7 +25,16 @@ find_path(PCRE_INCLUDE_DIR NAMES pcre2.h)
 # Look for the library
 # - sets PCRE_LIBRARY (e.g.: /usr/lib/x86_64-linux-gnu/libpcre2-8.so),
 #        PCRE_INCLUDE_DIR (e.g., /usr/include)
-find_library(PCRE_LIBRARY NAMES pcre2-8)
+# On Windows with vcpkg, handle separate debug/release libraries (pcre2-8d vs pcre2-8)
+if(WIN32)
+	find_library(PCRE_LIBRARY_RELEASE NAMES pcre2-8)
+	find_library(PCRE_LIBRARY_DEBUG NAMES pcre2-8d pcre2-8)
+
+	include(SelectLibraryConfigurations)
+	select_library_configurations(PCRE)
+else()
+	find_library(PCRE_LIBRARY NAMES pcre2-8)
+endif()
 
 # Handle the QUIETLY and REQUIRED arguments and set PCRE_FOUND to TRUE if all listed variables are TRUE.
 include(FindPackageHandleStandardArgs)


### PR DESCRIPTION
When building on Windows with vcpkg, the PCRE package was linking against the release library (pcre2-8.lib) even in Debug builds, causing the vcpkg applocal script to fail copying the correct debug DLL (pcre2-8d.dll).

This fix uses CMake's SelectLibraryConfigurations module to properly detect and use pcre2-8d for Debug builds and pcre2-8 for Release builds on Windows, while maintaining existing behavior on other platforms.

Tested with Visual Studio 2026 and vcpkg on Windows 11.